### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/src/explorer/backend.py
+++ b/src/explorer/backend.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Union, Set
 from pydantic import BaseModel
 from datetime import datetime, timedelta
 import asyncio
+import logging
 from ..networking.node import Node
 from ..blockchain.blockchain import Blockchain
 
@@ -209,11 +210,12 @@ async def root():
         update_cache('network_stats', stats)
         return stats
     except Exception as e:
+        logging.error("Exception in root endpoint", exc_info=True)
         return {
             "name": "Vernachain Explorer",
             "version": "0.2.0",
             "status": "error",
-            "error": str(e)
+            "error": "An internal error has occurred."
         }
 
 @app.get("/stats")


### PR DESCRIPTION
Potential fix for [https://github.com/BronzonTech-Cloud/vernachain/security/code-scanning/5](https://github.com/BronzonTech-Cloud/vernachain/security/code-scanning/5)

To fix the issue, any sensitive exception information (e.g., the exception message from `str(e)`) should not be included in the response sent to clients. Only a generic error message should be returned (e.g., "An internal error has occurred.") while retaining the more detailed exception information in server-side logs for debugging.

Specifically, in `src/explorer/backend.py`, lines 211–217 should be changed so that:
- The response omits `str(e)`, and instead returns a static, non-sensitive error message.
- Optionally, the exception details (including tracebacks) are logged to standard logging facilities for later investigation.
- This might require an import of the `logging` module (if it isn't already present in this shown region).

You should add/import logging at the top, configure it minimally if needed, and use `logging.error` to log the stack trace.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling on the root endpoint to return a clear, generic error message instead of exposing internal details.
  * Enhanced reliability by ensuring exceptions are gracefully caught and communicated to users.

* **Chores**
  * Added error logging to capture exceptions for troubleshooting without impacting user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->